### PR TITLE
build: Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ rgb-schemata = { git = "https://github.com/RGB-WG/rgb-schemata", branch = "maste
 [profile.release]
 debug = 0
 lto = "off"
+
+[workspace]


### PR DESCRIPTION
bitlight-rgb20-contract % make run
cargo run --bin bitlight-rgb20-contract
error: current package believes it's in a workspace when it's not:
current:   /Users/vincent/bitlightlabs/rgb/bitlight-rgb20-contract/Cargo.toml
workspace: /Users/vincent/bitlightlabs/rgb/Cargo.toml

this may be fixable by adding `bitlight-rgb20-contract` to the `workspace.members` array of the manifest located at: /Users/vincent/bitlightlabs/rgb/Cargo.toml Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest. make: *** [run] Error 101